### PR TITLE
chore: bump version to v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [0.4.0] – 2026-02-26
+
+### Added
+- Add philosophy document and update links in README; adjust argument names in analyzers (#90)
+- enhance language analyzers with AST parsing capabilities (#71)
+
+### Fixed
+- Improve branch creation checks and add tests for uncommitted changes (#87)
+
+### Documentation
+- MCP-first reorientation of README.md and installation docs (#70)
+
 ## [0.3.0] – 2026-02-22
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-zen-of-languages"
-version = "0.3.0"
+version = "0.4.0"
 description = "Multi-language architectural and idiomatic code analysis via CLI and MCP server."
 readme = "README.md"
 authors = [{ name = "Anselm Hahn", email = "Anselm.Hahn@gmail.com" }]

--- a/src/mcp_zen_of_languages/__init__.py
+++ b/src/mcp_zen_of_languages/__init__.py
@@ -19,4 +19,4 @@ Attributes:
     __version__: Semantic version string for the installed package.
 """
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1034,7 +1034,7 @@ wheels = [
 
 [[package]]
 name = "mcp-zen-of-languages"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp", extra = ["tasks"] },


### PR DESCRIPTION
This pull request introduces version 0.4.0 of the package, bringing several enhancements, fixes, and documentation improvements. The most notable changes are the addition of AST parsing capabilities to language analyzers, improved branch creation checks, and a reorientation of documentation to emphasize MCP-first usage.

Versioning and release updates:

* Updated the package version to `0.4.0` in `pyproject.toml` and `src/mcp_zen_of_languages/__init__.py`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-a7606989dc7586074b041fa6ec6674e73c266cfb464727628932ac46d9754f14L22-R22)
* Added a new release entry for `0.4.0` in `CHANGELOG.md`, detailing new features, fixes, and documentation updates.

Feature enhancements:

* Enhanced language analyzers with AST parsing capabilities, improving analysis precision.
* Added a philosophy document, updated links in the `README`, and adjusted argument names in analyzers for clarity and usability.

Bug fixes and documentation:

* Improved branch creation checks and added tests for handling uncommitted changes.
* Reoriented `README.md` and installation docs to prioritize MCP-first workflows.