### PR TITLE
feat: enhance branch creation with normalization and dry-run tests

### DIFF
--- a/scripts/branch.py
+++ b/scripts/branch.py
@@ -129,13 +129,27 @@ def _commits_ahead(base_ref: str) -> list[str]:
     return [line for line in out.splitlines() if line]
 
 
+def _normalize_commit_type(value: str) -> str:
+    normalized = value.lower()
+    if normalized not in CONVENTIONAL_TYPES:
+        allowed = ", ".join(CONVENTIONAL_TYPES)
+        msg = f"invalid conventional type: {value!r} (choose one of: {allowed})"
+        raise argparse.ArgumentTypeError(msg)
+    return normalized
+
+
+def _join_description(parts: list[str]) -> str:
+    return " ".join(parts).strip()
+
+
 # ---------------------------------------------------------------------------
 # `new` subcommand
 # ---------------------------------------------------------------------------
 
 
 def cmd_new(args: argparse.Namespace) -> None:
-    branch = BranchName(type=args.type, description=args.description, scope=args.scope)
+    description = _join_description(args.description)
+    branch = BranchName(type=args.type, description=description, scope=args.scope)
     branch_name = branch.slug()
     commit_title = branch.commit_title()
 
@@ -175,7 +189,8 @@ def cmd_new(args: argparse.Namespace) -> None:
 
 
 def cmd_rescue(args: argparse.Namespace) -> None:
-    branch = BranchName(type=args.type, description=args.description, scope=args.scope)
+    description = _join_description(args.description)
+    branch = BranchName(type=args.type, description=description, scope=args.scope)
     branch_name = branch.slug()
     commit_title = branch.commit_title()
 
@@ -279,12 +294,14 @@ def main() -> None:
     )
     new_p.add_argument(
         "type",
-        choices=CONVENTIONAL_TYPES,
+        type=_normalize_commit_type,
+        metavar="TYPE",
         help="Conventional commit type (feat, fix, chore, …).",
     )
     new_p.add_argument(
         "description",
-        help="Short description — becomes the branch slug.",
+        nargs="+",
+        help="Short description (one or more words) — becomes the branch slug.",
     )
     new_p.add_argument(
         "--scope",
@@ -307,12 +324,14 @@ def main() -> None:
     )
     rescue_p.add_argument(
         "type",
-        choices=CONVENTIONAL_TYPES,
+        type=_normalize_commit_type,
+        metavar="TYPE",
         help="Conventional commit type for the rescue branch.",
     )
     rescue_p.add_argument(
         "description",
-        help="Short description for the rescue branch.",
+        nargs="+",
+        help="Short description (one or more words) for the rescue branch.",
     )
     rescue_p.add_argument(
         "--scope",

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -14,7 +14,7 @@ Steps performed:
     3. Update pyproject.toml  [version = "…"]
     4. Update src/…/__init__.py  [__version__ = "…"]
     5. Update CHANGELOG.md  (git log since last tag, grouped by type)
-    6. Run ``uv lock`` to refresh uv.lock
+    6. Run ``uv lock -U`` to refresh uv.lock
     7. ``git checkout -b release/v{new}``
     8. ``git add pyproject.toml uv.lock src/…/__init__.py CHANGELOG.md``
     9. ``git commit -m "chore: bump version to v{new}"``
@@ -367,12 +367,49 @@ def _working_tree_clean() -> bool:
     return result.stdout.strip() == ""
 
 
+def _confirm_branch_overwrite(branch: str) -> bool:
+    prompt = f"⚠  Branch '{branch}' already exists.\n   Delete and recreate it? [y/N]: "
+    while True:
+        response = input(prompt).strip().lower()
+        if response in {"y", "yes"}:
+            return True
+        if response in {"", "n", "no"}:
+            return False
+        print("Please answer 'y' or 'n'.")
+
+
+def _prepare_release_branch(branch_name: str, *, base: str, dry_run: bool) -> None:
+    if dry_run or not _branch_exists(branch_name):
+        return
+
+    if not _confirm_branch_overwrite(branch_name):
+        print(
+            f"i  Aborting: branch '{branch_name}' was kept unchanged.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    current = _current_branch()
+    if current == branch_name and base == branch_name:
+        print(
+            f"⚠  Branch '{branch_name}' is currently checked out.\n"
+            "   Pass --base-branch <branch> to recreate it from another branch.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if current == branch_name:
+        _run(["git", "checkout", base], dry_run=False, label="git checkout base")
+
+    _run(["git", "branch", "-D", branch_name], dry_run=False, label="git branch -D")
+
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
 
-def main() -> None:  # noqa: C901, PLR0915
+def main() -> None:  # noqa: PLR0915
     parser = argparse.ArgumentParser(
         description="Bump version, refresh uv.lock, and create a release branch.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -427,6 +464,8 @@ def main() -> None:  # noqa: C901, PLR0915
     print(f"Target branch: {branch_name}\n")
 
     # --- Safety checks ---
+    base = args.base_branch or _current_branch()
+
     if not args.dry_run:
         if not _working_tree_clean():
             print(
@@ -435,16 +474,9 @@ def main() -> None:  # noqa: C901, PLR0915
                 file=sys.stderr,
             )
             sys.exit(1)
-        if _branch_exists(branch_name):
-            print(
-                f"⚠  Branch '{branch_name}' already exists.\n"
-                "   Delete it first or choose a different version.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+        _prepare_release_branch(branch_name, base=base, dry_run=False)
 
     # --- Base branch ---
-    base = args.base_branch or _current_branch()
     if not args.dry_run and _current_branch() != base:
         _run(["git", "checkout", base], dry_run=False, label="git checkout base")
 
@@ -466,7 +498,7 @@ def main() -> None:  # noqa: C901, PLR0915
 
     # 2. Refresh lockfile
     print("\n── Refreshing uv.lock ───────────────────────────────────────")
-    _run(["uv", "lock"], dry_run=args.dry_run, label="uv lock")
+    _run(["uv", "lock", "-U"], dry_run=args.dry_run, label="uv lock -U")
 
     # 3. Create branch
     print("\n── Git ───────────────────────────────────────────────────────")

--- a/tests/test_branch_script.py
+++ b/tests/test_branch_script.py
@@ -149,6 +149,12 @@ class TestNewCommandDryRun:
         result = _run_branch("new", "invalid_type", "something", "--dry-run")
         assert result.returncode != 0
 
+    def test_dry_run_accepts_uppercase_type_and_unquoted_description(self):
+        result = _run_branch("new", "FEAT", "Feature", "Update", "lock", "--dry-run")
+        assert result.returncode == 0
+        assert "feat/feature-update-lock" in result.stdout
+        assert "feat: Feature Update lock" in result.stdout
+
 
 class TestRescueCommandDryRun:
     def test_dry_run_exits_zero(self):
@@ -167,6 +173,18 @@ class TestRescueCommandDryRun:
     def test_dry_run_complete_marker(self):
         result = _run_branch("rescue", "feat", "my feature", "--dry-run")
         assert "dry-run complete" in result.stdout
+
+    def test_dry_run_accepts_uppercase_type_and_unquoted_description(self):
+        result = _run_branch(
+            "rescue",
+            "FIX",
+            "Feature",
+            "Update",
+            "lock",
+            "--dry-run",
+        )
+        assert result.returncode == 0
+        assert "fix/feature-update-lock" in result.stdout
 
 
 class TestHelpText:

--- a/tests/test_bump_version_script.py
+++ b/tests/test_bump_version_script.py
@@ -1,0 +1,97 @@
+"""Tests for branch-conflict helpers in scripts/bump_version.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+BUMP_SCRIPT = ROOT / "scripts" / "bump_version.py"
+
+
+def _import_bump():
+    spec = importlib.util.spec_from_file_location("bump_version", BUMP_SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["bump_version"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+bv = _import_bump()
+
+
+class TestConfirmBranchOverwrite:
+    def test_yes_returns_true(self, monkeypatch):
+        monkeypatch.setattr("builtins.input", lambda _prompt: "y")
+        assert bv._confirm_branch_overwrite("release/v1.2.3") is True
+
+    def test_empty_returns_false(self, monkeypatch):
+        monkeypatch.setattr("builtins.input", lambda _prompt: "")
+        assert bv._confirm_branch_overwrite("release/v1.2.3") is False
+
+    def test_retries_on_invalid_input(self, monkeypatch, capsys):
+        responses = iter(["maybe", "yes"])
+        monkeypatch.setattr("builtins.input", lambda _prompt: next(responses))
+        assert bv._confirm_branch_overwrite("release/v1.2.3") is True
+        assert "Please answer 'y' or 'n'." in capsys.readouterr().out
+
+
+class TestPrepareReleaseBranch:
+    def test_skips_when_branch_does_not_exist(self, monkeypatch):
+        monkeypatch.setattr(bv, "_branch_exists", lambda _branch: False)
+        bv._prepare_release_branch("release/v1.2.3", base="main", dry_run=False)
+
+    def test_aborts_when_user_declines_overwrite(self, monkeypatch):
+        monkeypatch.setattr(bv, "_branch_exists", lambda _branch: True)
+        monkeypatch.setattr(bv, "_confirm_branch_overwrite", lambda _branch: False)
+        with pytest.raises(SystemExit, match="1"):
+            bv._prepare_release_branch("release/v1.2.3", base="main", dry_run=False)
+
+    def test_deletes_existing_branch_when_confirmed(self, monkeypatch):
+        monkeypatch.setattr(bv, "_branch_exists", lambda _branch: True)
+        monkeypatch.setattr(bv, "_confirm_branch_overwrite", lambda _branch: True)
+        monkeypatch.setattr(bv, "_current_branch", lambda: "main")
+        calls: list[list[str]] = []
+
+        def _fake_run(cmd: list[str], *, dry_run: bool, label: str) -> None:
+            assert dry_run is False
+            assert label
+            calls.append(cmd)
+
+        monkeypatch.setattr(bv, "_run", _fake_run)
+        bv._prepare_release_branch("release/v1.2.3", base="main", dry_run=False)
+        assert calls == [["git", "branch", "-D", "release/v1.2.3"]]
+
+    def test_checks_out_base_before_delete_if_branch_is_current(self, monkeypatch):
+        monkeypatch.setattr(bv, "_branch_exists", lambda _branch: True)
+        monkeypatch.setattr(bv, "_confirm_branch_overwrite", lambda _branch: True)
+        monkeypatch.setattr(bv, "_current_branch", lambda: "release/v1.2.3")
+        calls: list[list[str]] = []
+
+        def _fake_run(cmd: list[str], *, dry_run: bool, label: str) -> None:
+            assert dry_run is False
+            assert label
+            calls.append(cmd)
+
+        monkeypatch.setattr(bv, "_run", _fake_run)
+        bv._prepare_release_branch("release/v1.2.3", base="main", dry_run=False)
+        assert calls == [
+            ["git", "checkout", "main"],
+            ["git", "branch", "-D", "release/v1.2.3"],
+        ]
+
+    def test_aborts_when_current_and_base_are_same_release_branch(self, monkeypatch):
+        monkeypatch.setattr(bv, "_branch_exists", lambda _branch: True)
+        monkeypatch.setattr(bv, "_confirm_branch_overwrite", lambda _branch: True)
+        monkeypatch.setattr(bv, "_current_branch", lambda: "release/v1.2.3")
+        with pytest.raises(SystemExit, match="1"):
+            bv._prepare_release_branch(
+                "release/v1.2.3",
+                base="release/v1.2.3",
+                dry_run=False,
+            )


### PR DESCRIPTION
This pull request introduces several improvements to the branch management and release workflow scripts, focusing on better argument handling, safer branch overwrites, and enhanced test coverage. The most significant changes include allowing multi-word branch descriptions without quotes, normalizing commit types, adding user confirmation before overwriting existing release branches, and updating the lockfile refresh command. Comprehensive tests have been added to ensure the new behaviors work as intended.

**Branch creation and argument handling improvements:**

* The `new` and `rescue` subcommands in `scripts/branch.py` now accept multi-word descriptions as separate arguments (no need for quotes), and descriptions are joined into a single string for branch naming. Commit types are normalized to lowercase and validated, improving usability and preventing errors. (`[[1]](diffhunk://#diff-1b74c7379a517fb08329bd8f6b30c8f5458661750e5a530bbf07841225712406R132-R152)`, `[[2]](diffhunk://#diff-1b74c7379a517fb08329bd8f6b30c8f5458661750e5a530bbf07841225712406L178-R193)`, `[[3]](diffhunk://#diff-1b74c7379a517fb08329bd8f6b30c8f5458661750e5a530bbf07841225712406L282-R304)`, `[[4]](diffhunk://#diff-1b74c7379a517fb08329bd8f6b30c8f5458661750e5a530bbf07841225712406L310-R334)`)
* Tests were added to verify that uppercase commit types and unquoted multi-word descriptions are accepted and correctly processed. (`[[1]](diffhunk://#diff-7c416e33f4e6e4bec990cece3889d0fe04c3e1697e0cc03458b626be3323e21aR152-R157)`, `[[2]](diffhunk://#diff-7c416e33f4e6e4bec990cece3889d0fe04c3e1697e0cc03458b626be3323e21aR177-R188)`)

**Release branch safety and workflow enhancements:**

* A new helper function prompts the user for confirmation before deleting and recreating an existing release branch, reducing the risk of accidental data loss. The workflow now safely checks out the base branch before deleting if the current branch matches the release branch, and aborts if both are the same. (`[[1]](diffhunk://#diff-0084ac8d45153c777a46c14679c3c543ae4324fb69a39f35962bf02ac22c6366R370-R412)`, `[[2]](diffhunk://#diff-0084ac8d45153c777a46c14679c3c543ae4324fb69a39f35962bf02ac22c6366R467-R468)`, `[[3]](diffhunk://#diff-0084ac8d45153c777a46c14679c3c543ae4324fb69a39f35962bf02ac22c6366L438-L447)`)
* The lockfile refresh command in both documentation and code is updated to use `uv lock -U` for a more thorough update. (`[[1]](diffhunk://#diff-0084ac8d45153c777a46c14679c3c543ae4324fb69a39f35962bf02ac22c6366L17-R17)`, `[[2]](diffhunk://#diff-0084ac8d45153c777a46c14679c3c543ae4324fb69a39f35962bf02ac22c6366L469-R501)`)

**Test coverage improvements:**

* A new test module, `tests/test_bump_version_script.py`, thoroughly tests the new branch overwrite confirmation logic and the release branch preparation workflow, including user prompts and error handling. (`[tests/test_bump_version_script.pyR1-R97](diffhunk://#diff-45a24fce76be84264872c8a66129b966be11647d581a12fd8c95099c1529c834R1-R97)`)